### PR TITLE
Added command-line args and fixed issue with set_mode() being called incorrectly

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -15,5 +15,5 @@ Gameplay:
 Install and Run:
 
 	git clone https://github.com/griffinjb/adaptive_ai.git
-
+	pip install -r requirements.txt
 	python simple_game.py

--- a/interface.py
+++ b/interface.py
@@ -28,7 +28,7 @@ import time
 
 class Interface:
 
-	def __init__(self):
+	def __init__(self, args):
 
 		self.move = queue.Queue()
 		self.render = queue.Queue()
@@ -37,14 +37,17 @@ class Interface:
 		self.I.start()
 
 		self.screen_size = [800,800]
-
 		self.quit_flag = False
+
+		# From command-line arguments
+		self.display_flags = pygame.FULLSCREEN | pygame.RESIZABLE
+		if args.windowed:
+			self.display_flags ^= pygame.FULLSCREEN
 
 	def main_thread(self):
 
 		pygame.init()
-		# self.screen = pygame.display.set_mode(self.screen_size,pygame.RESIZABLE)
-		self.screen = pygame.display.set_mode(self.screen_size,pygame.FULLSCREEN,pygame.RESIZABLE)
+		self.screen = pygame.display.set_mode(self.screen_size, self.display_flags)
 		pygame.event.set_blocked(None)
 		pygame.event.set_allowed([
 								pygame.KEYDOWN,
@@ -74,17 +77,21 @@ class Interface:
 			if event.unicode == 'd':
 				self.move.put(4)
 			if event.key == pygame.K_F11:
-				print(self.screen.get_flags() & pygame.FULLSCREEN)
 				if (self.screen.get_flags() & pygame.FULLSCREEN):
-					self.screen = pygame.display.set_mode(self.screen_size,pygame.RESIZABLE)
+					self.display_flags ^= pygame.FULLSCREEN
 				else:
-					self.screen = pygame.display.set_mode(self.screen_size,pygame.FULLSCREEN,pygame.RESIZABLE)
+					self.display_flags |= pygame.FULLSCREEN
+				# Update display flags
+				self.screen = pygame.display.set_mode(self.screen_size, self.display_flags)
 			if event.key == pygame.K_ESCAPE:
 				self.quit_flag = True
 
 		if event.type == pygame.VIDEORESIZE:
+			# XXX: When VIDEORESIZE is triggered by set_mode event, event.size
+			# is not correct?
 			self.screen_size = list(event.size)
-			self.screen = pygame.display.set_mode(event.size,pygame.RESIZABLE)
+			# XXX: Why is this needed?
+			self.screen = pygame.display.set_mode(self.screen_size, self.display_flags)
 
 		if event.type == pygame.QUIT:
 			self.quit_flag = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+matplotlib
+scipy
+pygame

--- a/simple_game.py
+++ b/simple_game.py
@@ -1,6 +1,7 @@
 from agent import *
 from player import *
 from interface import *
+import argparse
 import sys
 
 # Features:
@@ -19,12 +20,19 @@ class simple_game:
 
 	def __init__(self,resource_density=[.8,.01,.19]):
 
+		parser = argparse.ArgumentParser()
+		# --windowed
+		parser.add_argument('--windowed',
+				action='store_true',
+				help='Starts game in windowed mode')
+		args = parser.parse_args()
+
 		self.xmin = -5
 		self.xmax = 5
 		self.ymax = 5
 		self.ymin = -5
 
-		self.interface = Interface()
+		self.interface = Interface(args)
 
 		self.resource_density = resource_density 
 


### PR DESCRIPTION
**Additions:**
- Updated README to reflect requirements.txt being added to install dependencies
- Added --windowed option to support launching in windowed mode
- Added display_flags variable in interface.py to make it easier to call set_mode()

**Bug Fixes:**
I believe set_mode() was being called incorrectly on lines like the one below. This is addressed with new display_flags variable.
https://github.com/griffinjb/adaptive_ai/blob/2d1a0768f7ecccfc1e1f38a94b735abcfbc90100/interface.py#L47

See Pygame source here: https://github.com/pygame/pygame/blob/master/src_c/display.c#L866